### PR TITLE
Added IP SANS support and fixed user overwrite scope issues

### DIFF
--- a/bin/ca-create-cert
+++ b/bin/ca-create-cert
@@ -171,6 +171,7 @@ if [ 1 -ne "$CSR_ONLY" ]; then
         fi
         openssl ca -config "$CA_HOME/cnf/$CA_NAME.ca.cnf" \
           -days    "$CA_CRT_DAYS" \
+          -md      "$CA_DEFAULT_MD" \
           -extfile "$CA_HOME/cnf/$CNF_NAME.ext.cnf" -batch \
           -out     "$CA_HOME/crt/$CNF_NAME.crt" \
           -in      "$CA_HOME/csr/$CNF_NAME.csr"

--- a/bin/ca-create-cert
+++ b/bin/ca-create-cert
@@ -25,6 +25,7 @@ Options:
   -d, --days DAYS       Certificate valid for DAYS days instead of CA_CRT_DAYS
   -b, --bits BITS       Generate a BITS bit certificate instead of CA_CRT_BITS
   -n, --alt-name NAME   Alternative host name (can be provided multiple times)
+  -i, --ip IP ADDRESS   IP addresses to include in the certificate
   -p, --pkcs12          Create PKCS#12 certificate archive from generated cert
   -q, --no-qualify      Don't qualify short (dotless) names with CA_DOMAIN
   -r, --req-only        Only generate CSR, don't sign it
@@ -41,8 +42,8 @@ Options:
 __EOT__
 }
 
-short="hcf:t:d:b:n:pqrsx"
-long="help,encrypt,config:,type:,days:,bits:,alt-name:"
+short="hcf:t:d:b:n:i:pqrsx"
+long="help,encrypt,config:,type:,days:,bits:,alt-name:,ip:"
 long="$long,pkcs12,no-qualify,req-only,sign-only,cnf-only"
 long="$long,country:,state:,loc:,org:,ounit:,email:,comment:"
 opts=$( getopt -o "$short" -l "$long" -n "$PROGNAME" -- "$@" )
@@ -58,6 +59,7 @@ while :; do
         -d|--days) shift; USER_CA_CRT_DAYS="$1"; shift;;
         -b|--bits) shift; USER_CA_CRT_BITS="$1"; shift;;
         -n|--alt-name) shift; ALT_NAMES+=("$1"); shift;;
+        -i|--ip) shift; ALT_IPS+=("$1"); shift;;
         -p|--pkcs12) MAKE_P12=1; shift;;
         -q|--no-qualify) QUALIFY=0; shift;;
         -r|--req-only) CSR_ONLY=1; shift;;
@@ -129,6 +131,12 @@ if [ "$CA_CRT_TYPE" != "user" ]; then
         fi
         CA_CRT_ALT_NAMES="${CA_CRT_ALT_NAMES}DNS.$i=$ALT_NAME\n"
         i=$(( $i+1 ))
+    done
+.   p=1
+    for ALT_IP in "${ALT_IPS[@]}"; do
+        # add ips as IP.x
+            CA_CRT_ALT_NAMES="${CA_CRT_ALT_NAMES}IP.$p=$ALT_IP\n"
+            p=$(( $p+1 ))
     done
 fi
 

--- a/bin/ca-init
+++ b/bin/ca-init
@@ -95,6 +95,7 @@ if [ 1 -ne "$CNF_ONLY" ]; then
 
     openssl ca -create_serial -selfsign -days "$CA_DAYS" -batch \
       -name ca_scripts -extensions ca_x509_extensions \
+      -md      "$CA_DEFAULT_MD" \
       -config  "$CA_HOME/cnf/$CA_NAME.ca.cnf" \
       -in      "$CA_HOME/csr/$CA_NAME.ca.csr" \
       -keyfile "$CA_HOME/key/$CA_NAME.ca.key" \

--- a/ca-scripts.conf
+++ b/ca-scripts.conf
@@ -46,6 +46,11 @@ CA_DN_CN="Example Security Services Root Certificate Authority"
 # Default value:
 # CA_CRT_BITS=2048
 
+# OPTIONAL: CA_DEFAULT_MD sets the default message digest of generated
+# certificates.
+# Default value:
+CA_DEFAULT_MD="sha256"
+
 # OPTIONAL: CA_CRT_TYPE sets the default type of generated certificate.
 # Default value:
 # CA_CRT_TYPE="server"

--- a/lib/ca-functions
+++ b/lib/ca-functions
@@ -137,6 +137,7 @@ CA_CRT_L        $CA_DN_L
 CA_CRT_O        $CA_DN_O
 CA_CRT_OU       $CA_DN_OU
 CA_CRT_E        $CA_EMAIL
+CA_DEFAULT_MD   sha256
 __DEFAULTS__
 }
 

--- a/lib/ca-functions
+++ b/lib/ca-functions
@@ -3,9 +3,9 @@
 
 PROGNAME=$( basename $0 )
 CONFFILE="/etc/ca-scripts.conf"
+OVERRIDE_FILE=/tmp/$$ca_overrides.conf
 SHAREDIR=$(dirname $(readlink -f $0))/../tpl
 CRYPTKEY="-nodes"
-
 INDEXTPL="index-html"
 INDEXOUT=""
 
@@ -33,8 +33,13 @@ ca_check_var() {
 ca_override_conf() {
     local varname
 
+
     varname="${1#USER_}"
-    eval "$varname=\"\$USER_$varname\""
+    #eval "$varname=\"\$USER_$varname\""
+.   # fix for user overrides scope issue
+.   # push variables to a file to source them later
+    echo "$varname=\"\$USER_$varname\"" >> $OVERRIDE_FILE
+
 }
 
 ca_set_default() {
@@ -106,7 +111,11 @@ __TESTS__
     set | awk -F\= '/^USER_CA_[A-Z_]*=/{print $1}' | while read user_var; do
         ca_override_conf "$user_var"
     done
-
+.   #Check if fike containing user overrides exist
+.   # the file is created if any USER_CA.* variables are set
+     [ -f $OVERRIDE_FILE ] && source $OVERRIDE_FILE
+.   # remove file after sourcing it
+     [ -f $OVERRIDE_FILE ] && rm -rf $OVERRIDE_FILE
     # XXX: and this alternative should probably have better validation ;-)
     case "$CA_CRT_TYPE" in
         server|client|user) :;;


### PR DESCRIPTION
This pull request includes the commit from Author: Ricardo Bartolome <ricardo@tuenti.com> which changes the default MD to sha256

The request also includes added support for IP SANS (subject alternative names IP) 

The pull request also includes a fix to a scoping issue where USER_CA overrides are ignored.

This pull request also fixes issue #5. the problem was the the setup defaults to server if the CA_CERT_TYPE is set to server and it always ignores a user define type set with the -t and --type command line options.