### PR TITLE
MacOS support, configs per dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PKG_NAME=$(NAME)_$(VERSION)
 PKG=$(PKG_DIR)/$(PKG_NAME).tar.gz
 SIG=$(PKG_DIR)/$(PKG_NAME).asc
 
-PREFIX?=/opt/$(NAME)
+PREFIX?=/usr/local/$(NAME)
 DOC_DIR=$(PREFIX)/doc
 #DOC_DIR=$(PREFIX)/share/doc/$(PKG_NAME)
 
@@ -42,21 +42,21 @@ tag:
 
 release: $(PKG) $(SIG) tag
 
-install:
+install:	
 	for dir in $(INSTALL_DIRS); do mkdir -p $(PREFIX)/$$dir; done
 	for file in $(INSTALL_FILES); do cp $$file $(PREFIX)/$$file; done
 	mkdir -p $(DOC_DIR)
 	cp -r $(DOC_FILES) $(DOC_DIR)/
 
 symlinks:
-	for link in $(SCRIPTS); do ln -s $(PREFIX)/bin/$$link /usr/local/bin/$$link
+	for link in $(SCRIPTS); do ln -s $(PREFIX)/bin/$$link /usr/local/bin/$$link; done
 
 uninstall:
 	for file in $(INSTALL_FILES); do rm -f $(PREFIX)/$$file; done
 	rm -rf $(DOC_DIR)
 
 rmsymlinks:
-	for link in $(SCRIPTS); do rm -f /usr/local/bin/$$link
+	for link in $(SCRIPTS); do rm -f /usr/local/bin/$$link; done
 
 
 .PHONY: build sign clean test tag release install uninstall all

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ This will by default install to `/usr/local`, either `export PREFIX=/path` or
 `make PREFIX=/path; sudo make PREFIX=/path install` to change this to an
 alternative location.
 
+MacOS note
+------------
+
+To make ca-scripts work on MacOS you have to install the following
+
+```
+brew install coreutils
+brew install gnu-getopt
+brew install gnu-sed
+```
+
 Creating a Certificate Authority
 --------------------------------
 

--- a/bin/ca-create-cert
+++ b/bin/ca-create-cert
@@ -1,5 +1,13 @@
 #!/bin/bash
 set -e
+
+#Add GNU tools to path for MacOS
+if [ "Darwin" = `uname -s` ]; then
+    export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+    export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+    export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"            
+fi
+
 source $(dirname $(readlink -f $0))/../lib/ca-functions
 
 ALT_NAMES=()

--- a/bin/ca-init
+++ b/bin/ca-init
@@ -1,5 +1,13 @@
 #!/bin/bash
 set -e
+
+#Add GNU tools to path for MacOS
+if [ "Darwin" = `uname -s` ]; then
+    export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+    export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+    export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"            
+fi
+
 source $(dirname $(readlink -f $0))/../lib/ca-functions
 
 # XXX: Add an interactive mode to this script to obviate the need for a

--- a/bin/ca-list-certs
+++ b/bin/ca-list-certs
@@ -1,5 +1,13 @@
 #!/bin/bash
 set -e
+
+#Add GNU tools to path for MacOS
+if [ "Darwin" = `uname -s` ]; then
+    export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+    export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+    export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"            
+fi
+
 source $(dirname $(readlink -f $0))/../lib/ca-functions
 
 usage() {

--- a/bin/ca-renew-cert
+++ b/bin/ca-renew-cert
@@ -1,5 +1,13 @@
 #!/bin/bash
 set -e
+
+#Add GNU tools to path for MacOS
+if [ "Darwin" = `uname -s` ]; then
+    export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+    export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+    export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"            
+fi
+
 source $(dirname $(readlink -f $0))/../lib/ca-functions
 
 usage() {

--- a/bin/ca-revoke-cert
+++ b/bin/ca-revoke-cert
@@ -1,5 +1,13 @@
 #!/bin/bash
 set -e
+
+#Add GNU tools to path for MacOS
+if [ "Darwin" = `uname -s` ]; then
+    export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+    export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+    export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"            
+fi
+
 source $(dirname $(readlink -f $0))/../lib/ca-functions
 
 usage() {

--- a/ca-scripts.conf
+++ b/ca-scripts.conf
@@ -3,6 +3,7 @@
 
 # REQUIRED: CA_HOME provides the path to the root of the CA directory tree
 #           this directory must exist and be writeable
+# OPTIONAL for local configurations. Will be defaulted to current dir.
 #CA_HOME="/etc/ssl/ca-scripts"
 CA_HOME="/tmp/ca"
 

--- a/lib/ca-functions
+++ b/lib/ca-functions
@@ -120,12 +120,7 @@ __TESTS__
     # the file is created if any USER_CA.* variables are set
      [ -f $OVERRIDE_FILE ] && source $OVERRIDE_FILE
     # remove file after sourcing it
-     [ -f $OVERRIDE_FILE ] && rm -rf $OVERRIDE_FILE
-    # XXX: and this alternative should probably have better validation ;-)
-    case "$CA_CRT_TYPE" in
-        server|client|user) :;;
-        *) error "Unrecognised certificate type '$CA_CRT_TYPE'!";;
-    esac
+     [ -f $OVERRIDE_FILE ] && rm -rf $OVERRIDE_FILE    
 
     # we need to do these first to use them in other default defs
     # NOTE: bash's here-string syntax appends \n which tr turns to _ :(
@@ -153,6 +148,12 @@ CA_CRT_OU       $CA_DN_OU
 CA_CRT_E        $CA_EMAIL
 CA_DEFAULT_MD   sha256
 __DEFAULTS__
+
+# XXX: and this alternative should probably have better validation ;-)
+    case "$CA_CRT_TYPE" in
+        server|client|user) :;;
+        *) error "Unrecognised certificate type '$CA_CRT_TYPE'!";;
+    esac
 }
 
 # TODO: Remove this, as it's no longer used.

--- a/lib/ca-functions
+++ b/lib/ca-functions
@@ -2,7 +2,6 @@
 # Common functions for ca-scripts.
 
 PROGNAME=$( basename $0 )
-CONFFILE="/etc/ca-scripts.conf"
 OVERRIDE_FILE=/tmp/$$ca_overrides.conf
 SHAREDIR=$(dirname $(readlink -f $0))/../tpl
 CRYPTKEY="-nodes"
@@ -54,25 +53,31 @@ ca_set_default() {
 
 ca_load_conf() {
     local varname vartest varerr vardef error ca_name
-    if [ -r "$HOME/.ca-scripts.conf" ]; then
-        # Does a system-wide config exist? If so load it first.
+        
+    if [ -z "$CONFFILECLI" ]; then
+        # Load system config, user config, local config
+        if  ! [ -r "/etc/ca-scripts.conf" ] && ! [ -r "$HOME/.ca-scripts.conf" ] && ! [ -r "$(pwd)/ca-scripts.conf" ]; then
+            error "Default configuratation is not set. You can define default configuration at the following locations\n  /etc/ca-scripts.conf (System)\n  $HOME/.ca-scripts.conf (User)\n  $(pwd)/ca-scripts.conf (Local)"
+        fi
+
+        if [ -r "/etc/ca-scripts.conf" ]; then
+            source "/etc/ca-scripts.conf"            
+        fi
+        if [ -r "$HOME/.ca-scripts.conf" ]; then
+            source "$HOME/.ca-scripts.conf"
+        fi        
+        if [ -r "$(pwd)/ca-scripts.conf" ]; then
+            source "$(pwd)/ca-scripts.conf"
+            ca_set_default CA_HOME "$(pwd)"
+        fi
+    else         
         if [ -r "$CONFFILE" ]; then
             source "$CONFFILE"
-        fi
-        # Override system configuration with local values.
-	# If manually set on command-line, don't load.
-        if [ -z "$CONFFILECLI" ]; then
-            source "$HOME/.ca-scripts.conf"
-        fi
-    elif [ -r "$CONFFILE" ]; then
-        source "$CONFFILE"
-    else
-        if [ -n "$CONFFILECLI" ]; then
-            error "Unable to load $HOME/.ca-scripts.conf or $CONFFILE"
         else
             error "Unable to load $CONFFILE"
         fi
-    fi
+
+    fi    
 
     # TODO: Refactored config loader with error fallback, allowing local overrides.
     #if [ ! -r "$CONFFILE" ]; then

--- a/tpl/ca-config.tpl
+++ b/tpl/ca-config.tpl
@@ -146,8 +146,9 @@ default_md              = sha1
 distinguished_name      = ca_req_dn
 x509_extensions         = ca_x509_extensions
 req_extensions          = ca_req_extensions
-string_mask             = nombstr
 prompt                  = no
+string_mask 			= utf8only
+utf8        			= yes
 
 # ---------------------------------------------------------------------------- #
 # This defines the DN of the CA certificate.

--- a/tpl/req-config.tpl
+++ b/tpl/req-config.tpl
@@ -3,8 +3,9 @@ default_bits            = %CA_CRT_BITS%
 default_md              = sha1
 distinguished_name      = req_dn
 req_extensions          = req_%CA_CRT_TYPE%_extensions
-string_mask             = nombstr
 prompt                  = no
+string_mask 			= utf8only
+utf8        			= yes
 
 [ req_dn ]
 C                       = %CA_CRT_C%


### PR DESCRIPTION
Hi,

I made ca-scripts work on macos, added support for local ca-scripts.conf (imo it's easier to cd to a dir with config rather than set --config option for each command), few small fixes in Makefile and updated tpl files to always use utf8 (Not sure about this one, but as far as I understood utf8 is now a recommended setting). 