### PR TITLE
Fixed calculation error caused by invalid octal number

### DIFF
--- a/bin/ca-renew-cert
+++ b/bin/ca-renew-cert
@@ -15,6 +15,10 @@ Options:
 __EOT__
 }
 
+remove_leading_zeros() {
+	sed 's/^0\+//'
+}
+
 short="hf:t:d:"
 long="help,config:,type:,days:"
 opts=$( getopt -o "$short" -l "$long" -n "$PROGNAME" -- "$@" )
@@ -58,10 +62,10 @@ SERIAL=$( openssl x509 -in "$CRT" -noout -serial | cut -d= -f2 )
 # these dates are "<year> <day of year>"
 export TZ=UTC
 NOWYEAR=$( date +%Y )
-NOWDAYS=$( date +%j )
+NOWDAYS=$( date +%j | remove_leading_zeros )
 # XXX: this only works with GNU date, BSD portability fail.
 ENDYEAR=$( date +%Y -d "$ENDDATE + $CA_CRT_DAYS days" )
-ENDDAYS=$( date +%j -d "$ENDDATE + $CA_CRT_DAYS days" )
+ENDDAYS=$( date +%j -d "$ENDDATE + $CA_CRT_DAYS days" | remove_leading_zeros )
 CERTDATE=$( date +%Y-%m-%d -d "$ENDDATE" )
 
 # and this does the maths to work out how many days there are from now


### PR DESCRIPTION
"%j" format of GNU date command will be replaced a zero-padded 3 digit number.  When `day-of-year < 100`, leading character of `NOWDAYS` or `ENDDAYS` is '0' and bash interprets two variables as octal.

```
$ TZ= date +%j -d 2019-03-30
089
$ echo $(( 089 ))
bash: 089: value too great for base (error token is "089")
```